### PR TITLE
Update run_py.sh

### DIFF
--- a/examples/sscx_sample_dir/run_py.sh
+++ b/examples/sscx_sample_dir/run_py.sh
@@ -6,9 +6,4 @@ if [ ! -f "x86_64/special" ]; then
     nrnivmodl mechanisms
 fi
 
-if [ $# -eq 0 ]
-then
-    python -m emodelrunner.run
-else
-    python -m emodelrunner.run --config_path $1
-fi
+python -m emodelrunner.run --config_path $1


### PR DESCRIPTION
Setting a configuration file when running the sscx cell is now mandatory. Change the example run_py.sh accordingly.