### PR TITLE
Run coverage during the tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ envlist =
     lint
     py3-{unit,sscx,synplas}
     docs
-    coverage
 
 minversion = 3.7
 
@@ -22,7 +21,7 @@ ignore_basepython_conflict = true
 [gh-actions]
 python =
     3.7: py3
-    3.8: check-packaging, lint, docs, py3, coverage
+    3.8: check-packaging, lint, docs, py3
     3.9: py3
 
 [testenv]
@@ -35,19 +34,22 @@ envdir =
 deps = 
     {[base]testdeps}
     pathlib
+    coverage
+    pytest-cov
 passenv = KRB5CCNAME DISPLAY https_proxy USER
 whitelist_externals = make
+coverage_options = --cov-append --cov-report=xml --cov-config=.coveragerc
 commands =
     make clean
     make remove_test_output
 
-    unit: pytest -sx tests/unit_tests
+    unit: pytest -sx --cov=emodelrunner {[testenv]coverage_options} tests/unit_tests
 
     sscx: ./.compile_mod.sh examples/sscx_sample_dir mechanisms
-    sscx: pytest -sx tests/sscx_tests
+    sscx: pytest -sx --cov=emodelrunner {[testenv]coverage_options} tests/sscx_tests
 
     synplas: ./.compile_mod.sh examples/synplas_sample_dir mechanisms
-    synplas: pytest -sx tests/test_synplas.py
+    synplas: pytest -sx --cov=emodelrunner {[testenv]coverage_options} tests/test_synplas.py
 
 [testenv:check-packaging]
 envdir={toxworkdir}/{envname}
@@ -82,15 +84,6 @@ commands =
     black {[base]name}
     black tests
     black setup.py
-
-[testenv:coverage]
-envdir={toxworkdir}/{envname}
-usedevelop=True
-deps =
-    {[base]testdeps}
-    pytest-cov
-commands =
-    pytest --cov-report term-missing --cov-report xml --cov={[base]name} tests/
 
 [testenv:docs]
 envdir={toxworkdir}/{envname}


### PR DESCRIPTION
Run coverage during the tests instead of running it after the tests. This will save testing time.