### PR TITLE
thalamus: don't require bpo_threshold_current_dep's current

### DIFF
--- a/emodelrunner/protocols/create_protocols.py
+++ b/emodelrunner/protocols/create_protocols.py
@@ -158,6 +158,9 @@ class ProtocolBuilder:
             mtype (str): mtype to index the responses
             dt (float): timestep of the generated currents (ms)
 
+        Raises:
+            KeyError: when "dep" holding or threshold current is missing
+
         Returns:
             dict: the generated currents in a dict.
         """

--- a/emodelrunner/protocols/create_protocols.py
+++ b/emodelrunner/protocols/create_protocols.py
@@ -162,9 +162,12 @@ class ProtocolBuilder:
             dict: the generated currents in a dict.
         """
         thres_i_hyp = responses[f"{mtype}.bpo_threshold_current_hyp"]
-        thres_i_dep = responses[f"{mtype}.bpo_threshold_current_dep"]
         holding_i_hyp = responses[f"{mtype}.bpo_holding_current_hyp"]
-        holding_i_dep = responses[f"{mtype}.bpo_holding_current_dep"]
+        try:
+            thres_i_dep = responses[f"{mtype}.bpo_threshold_current_dep"]
+            holding_i_dep = responses[f"{mtype}.bpo_holding_current_dep"]
+        except KeyError:
+            thres_i_dep = holding_i_dep = None
         currents = {}
         for protocol in self.protocols.protocols:
             currents.update(

--- a/emodelrunner/protocols/thalamus_protocols.py
+++ b/emodelrunner/protocols/thalamus_protocols.py
@@ -51,7 +51,6 @@ class RatSSCxMainProtocol(ephys.protocols.Protocol):
         thdetect_protocol_hyp=None,
         other_protocols=None,
         pre_protocols=None,
-        fitness_calculator=None,
     ):
         """Constructor."""
         # pylint: disable=too-many-arguments
@@ -75,8 +74,6 @@ class RatSSCxMainProtocol(ephys.protocols.Protocol):
         self.other_protocols = other_protocols
 
         self.pre_protocols = pre_protocols
-
-        self.fitness_calculator = fitness_calculator
 
     def subprotocols(self):
         """Return all the subprotocols contained in this protocol, is recursive."""

--- a/tests/unit_tests/test_protocols.py
+++ b/tests/unit_tests/test_protocols.py
@@ -115,15 +115,17 @@ class TestProtocolBuilder:
         responses = {
             f"{mtype}.bpo_threshold_current_hyp": 0.1,
             f"{mtype}.bpo_holding_current_hyp": 0.3,
-            f"{mtype}.bpo_threshold_current_dep": 0.4
+            f"{mtype}.bpo_threshold_current_dep": 0.4,
         }
 
         mock_obj = SimpleNamespace(
-            protocols=[SimpleNamespace(generate_current=(lambda *args: {"args": args}))])
+            protocols=[SimpleNamespace(generate_current=(lambda *args: {"args": args}))]
+        )
 
         thal_protocols = ProtocolBuilder(protocols=mock_obj)
         currents = thal_protocols.get_thalamus_stim_currents(responses, mtype, dt=0.025)
         assert currents["args"] == (0.1, None, 0.3, None, 0.025)
+
 
 class TestProtocolParser:
     """Tests for the ProtocolParser class."""

--- a/tests/unit_tests/test_protocols.py
+++ b/tests/unit_tests/test_protocols.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from emodelrunner.load import (
     load_config,
@@ -108,6 +109,21 @@ class TestProtocolBuilder:
             }
             assert prot_obj_names - thalamus_recipe_protocol_keys == set()
 
+    def test_thalamus_stim_currents_exception(self):
+        """Tests the exception case in get_thalamus_stim_currents."""
+        mtype = "test_mtype"
+        responses = {
+            f"{mtype}.bpo_threshold_current_hyp": 0.1,
+            f"{mtype}.bpo_holding_current_hyp": 0.3,
+            f"{mtype}.bpo_threshold_current_dep": 0.4
+        }
+
+        mock_obj = SimpleNamespace(
+            protocols=[SimpleNamespace(generate_current=(lambda *args: {"args": args}))])
+
+        thal_protocols = ProtocolBuilder(protocols=mock_obj)
+        currents = thal_protocols.get_thalamus_stim_currents(responses, mtype, dt=0.025)
+        assert currents["args"] == (0.1, None, 0.3, None, 0.025)
 
 class TestProtocolParser:
     """Tests for the ProtocolParser class."""


### PR DESCRIPTION
Unlike the `bpo_threshold_current_hyp`, the voltage trace for the `bpo_threshold_current_dep` does not always have to be present. 
This PR generates the current only if the voltage is present.