### PR TITLE
Thalamus: fix mismatch voltage and current shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ examples/sscx_sample_dir/createsimulation.hoc
 examples/sscx_sample_dir/synapses/synapses.hoc
 examples/synplas_sample_dir/*.h5
 examples/thalamus_sample_dir/python_recordings
+.DS_STORE

--- a/emodelrunner/protocols/thalamus_protocols.py
+++ b/emodelrunner/protocols/thalamus_protocols.py
@@ -513,7 +513,7 @@ class RatSSCxRinHoldcurrentProtocol(ephys.protocols.Protocol):
             holding_current = self.rin_protocol.holding_stimulus.step_amplitude
         total_duration = self.rin_protocol.step_stimulus.total_duration
 
-        t = np.arange(0.0, total_duration, dt)
+        t = np.arange(0.0, total_duration + dt, dt)
         current = np.full(t.shape, holding_current, dtype="float64")
 
         ton = self.rin_protocol.step_stimulus.step_delay
@@ -866,7 +866,7 @@ class StepProtocolCustom(ephys.protocols.StepProtocol, CurrentOutputKeyMixin):
             holding_current = self.holding_stimulus.step_amplitude
         total_duration = self.step_stimulus.total_duration
 
-        t = np.arange(0.0, total_duration, dt)
+        t = np.arange(0.0, total_duration + dt, dt)
         current = np.full(t.shape, holding_current, dtype="float64")
 
         ton = self.step_stimulus.step_delay
@@ -990,7 +990,7 @@ class StepThresholdProtocol(StepProtocolCustom):
         # pylint: disable=signature-differs
         total_duration = self.step_stimulus.total_duration
 
-        t = np.arange(0.0, total_duration, dt)
+        t = np.arange(0.0, total_duration + dt, dt)
         current = np.full(t.shape, holding_current, dtype="float64")
 
         ton = self.step_stimulus.step_delay

--- a/tests/thalamus_tests/test_thalamus_functional.py
+++ b/tests/thalamus_tests/test_thalamus_functional.py
@@ -69,20 +69,39 @@ class TestMainProtocol:
 
         assert [f(step_200) != f(step_200_hyp) for f in [np.min, np.max, np.mean]]
 
+    @staticmethod
+    def get_corresponding_current_files(voltage_paths):
+        """Returns a list of current files for a list of voltage paths."""
+        mtypes = [x.name.split(".")[0] for x in voltage_paths]
+        prot_names = [x.name.split(".")[1] for x in voltage_paths]
+        return [
+            f"current_{mtype}.{prot}.dat" for (mtype, prot) in zip(mtypes, prot_names)
+        ]
+
     def test_current_traces_produced(self):
         """Test to check all produced voltage traces have corresponding current traces."""
         voltage_paths = list(
             Path(self.example_dir / "python_recordings").glob("*v.dat")
         )
-        mtypes = [x.name.split(".")[0] for x in voltage_paths]
-        prot_names = [x.name.split(".")[1] for x in voltage_paths]
+        matching_current_names = self.get_corresponding_current_files(voltage_paths)
 
         current_paths = list(
             Path(self.example_dir / "python_recordings").glob("current*.dat")
         )
         current_names = [x.name for x in current_paths]
-        matching_current_names = [
-            f"current_{mtype}.{prot}.dat" for (mtype, prot) in zip(mtypes, prot_names)
-        ]
-
         assert set(matching_current_names) == set(current_names)
+
+    def test_voltage_current_size(self):
+        """Test to assure the produced voltage and current have the same size."""
+        voltage_paths = list(
+            Path(self.example_dir / "python_recordings").glob("*v.dat")
+        )
+        matching_current_fnames = self.get_corresponding_current_files(voltage_paths)
+        voltage_fnames = [x.name for x in voltage_paths]
+
+        for voltage_fname, current_fname in zip(
+            voltage_fnames, matching_current_fnames
+        ):
+            voltage = np.loadtxt(self.example_dir / "python_recordings" / voltage_fname)
+            current = np.loadtxt(self.example_dir / "python_recordings" / current_fname)
+            assert voltage.shape == current.shape


### PR DESCRIPTION
After applying the Thalamus protocols, the voltage always has 1 more item than the current generated.
This can cause issues to the NWB users where the current and voltage pairs are stored together.

This PR adds a one extra item to the current generator to address the issue.
I haven't checked if the same issue exists in the SSCX protocols.