### PR TITLE
add logo similar to the GUI_scheenshot to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,7 @@
-.. image:: doc/source/logo/BBP-eModelRunner.jpg
+.. raw:: html
+
+    <img src="https://github.com/BlueBrain/EModelRunner/raw/main/doc/source/logo/BBP-eModelRunner.jpg"/>
+
 
 ############
 EModelRunner

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,4 @@
-.. raw:: html
-
-    <img src="https://github.com/BlueBrain/EModelRunner/raw/main/doc/source/logo/BBP-eModelRunner.jpg"/>
-
+|banner|
 
 ############
 EModelRunner
@@ -258,6 +255,7 @@ Copyright (c) 2020-2022 Blue Brain Project/EPFL
 
 .. |GUI_screenshot| image:: doc/source/images/GUI_screenshot.png
 
+.. |banner| image:: doc/source/logo/BBP-eModelRunner.jpg
 
 .. |gitter| image:: https://badges.gitter.im/BlueBrain/EmodelRunner.svg
    :alt: Join the chat at https://gitter.im/BlueBrain/EmodelRunner

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,6 +28,8 @@ import shutil
 
 Path("doc/source/images").mkdir(parents=True, exist_ok=True)
 shutil.copy("images/GUI_screenshot.png", "doc/source/images/GUI_screenshot.png")
+Path("doc/source/logo").mkdir(parents=True, exist_ok=True)
+shutil.copy("logo/BBP-eModelRunner.jpg", "doc/source/logo/BBP-eModelRunner.jpg")
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Although it works fine in BluePyOpt, when I instead use the local paths in the rst file, sphinx tries to load README.rst inside index.rst. As as result, the local path is becoming invalid. 

This PR solves the docs build failure by using html for the image link while keeping the image rendered at the README as well as the docs html generated.
