### PR TITLE
Fix diameter value in tests after neurom3.2.0 update

### DIFF
--- a/tests/unit_tests/data/hippocampus_morphometrics.json
+++ b/tests/unit_tests/data/hippocampus_morphometrics.json
@@ -33,7 +33,7 @@
         },
         {
             "name": "average diameter of all",
-            "value": 0.5396965742111206,
+            "value": 0.539696595209174,
             "unit": "\u00b5m"
         },
         {
@@ -93,7 +93,7 @@
         },
         {
             "name": "average diameter of axon",
-            "value": 0.398780882358551,
+            "value": 0.39878087863997674,
             "unit": "\u00b5m"
         },
         {
@@ -153,7 +153,7 @@
         },
         {
             "name": "average diameter of apical",
-            "value": 0.9227972030639648,
+            "value": 0.922797184065503,
             "unit": "\u00b5m"
         },
         {
@@ -213,7 +213,7 @@
         },
         {
             "name": "average diameter of basal",
-            "value": 0.6784688234329224,
+            "value": 0.678468805386857,
             "unit": "\u00b5m"
         },
         {


### PR DESCRIPTION
There is a small discrepancy in the value of some diameter features for the factsheets after the latest neurom update to 3.2.0. 