### PR TITLE
New github action to keep workflows alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,36 @@
+name: Keep-alive
+
+on:
+  schedule:
+    # Runs every sunday at 3 a.m.
+    - cron: '0 3 * * SUN'
+
+jobs:
+  call-test-workflow:
+    uses: BlueBrain/EModelRunner/.github/workflows/test.yml@main
+  
+  keep-workflow-alive:
+    name: Keep workflow alive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Get date from 50 days ago
+        run: |
+          datethen=`date -d "-50 days" --utc +%FT%TZ`
+          echo "datelimit=$datethen" >> $GITHUB_ENV
+
+      - name: setup git config
+        if: github.event.base.repo.updated_at <= env.datelimit
+        run: |
+          # setup the username and email.
+          git config user.name "Github Actions Keepalive Bot"
+          git config user.email "<>"
+
+      - name: commit IF last commit is older than 50 days
+        if: github.event.base.repo.updated_at <= env.datelimit
+        run: |
+          git commit -m "Empty commit to keep the gihub workflows alive" --allow-empty
+          git push origin main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  schedule:
-    # Runs every sunday at 3 a.m.
-    - cron: '0 3 * * SUN'
   push:
     branches:
       - main


### PR DESCRIPTION
The github actions get deactivated if the repo is inactive for 60 days or more.
This adds a check to the weekly scheduled workflow: if the last commit in main is older than 50 days, then the github action makes an empty commit to keep the repo active.