### PR TITLE
remove unused dependencies from tox.ini and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
 import sys
 
 from setuptools import setup, find_packages

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ name = emodelrunner
 testdeps =
     NEURON
     cmake
-    mock
     pytest
 
 [tox]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 name = emodelrunner
 testdeps =
     NEURON
-    cmake
     pytest
 
 [tox]


### PR DESCRIPTION
* removes the backport of the built-in unittest.mock module https://pypi.org/project/mock/
* removes the unused import imp in setup.py
* removes the cmake dependencies that is left from the times we had to build neuron using cmake