### PR TITLE
Config dataclasses

### DIFF
--- a/emodelrunner/GUI_utils/simulator.py
+++ b/emodelrunner/GUI_utils/simulator.py
@@ -28,7 +28,6 @@ from emodelrunner.load import (
     load_syn_mechs,
     load_unoptimized_parameters,
     load_mechanisms,
-    get_morph_args,
     get_release_params,
 )
 from emodelrunner.morphology import create_morphology
@@ -442,7 +441,7 @@ class NeuronSimulation:
         )
 
         # load morphology
-        morph_config = get_morph_args(self.config)
+        morph_config = self.config.morph_args()
         morph = create_morphology(morph_config, self.config.package_type)
 
         # create cell

--- a/emodelrunner/configuration/__init__.py
+++ b/emodelrunner/configuration/__init__.py
@@ -22,3 +22,6 @@ from emodelrunner.configuration.validator import (
     ThalamusConfigValidator,
 )
 from emodelrunner.configuration.configparser import PackageType
+from emodelrunner.configuration.subgroups import (
+    HocPaths, ProtArgs, SynMechArgs, MorphArgs, PresynStimArgs
+)

--- a/emodelrunner/configuration/__init__.py
+++ b/emodelrunner/configuration/__init__.py
@@ -23,5 +23,9 @@ from emodelrunner.configuration.validator import (
 )
 from emodelrunner.configuration.configparser import PackageType
 from emodelrunner.configuration.subgroups import (
-    HocPaths, ProtArgs, SynMechArgs, MorphArgs, PresynStimArgs
+    HocPaths,
+    ProtArgs,
+    SynMechArgs,
+    MorphArgs,
+    PresynStimArgs,
 )

--- a/emodelrunner/configuration/configparser.py
+++ b/emodelrunner/configuration/configparser.py
@@ -18,7 +18,13 @@
 from configparser import ConfigParser
 from enum import Enum
 
-from emodelrunner.configuration.subgroups import HocPaths, ProtArgs, SynMechArgs, MorphArgs, PresynStimArgs
+from emodelrunner.configuration.subgroups import (
+    HocPaths,
+    ProtArgs,
+    SynMechArgs,
+    MorphArgs,
+    PresynStimArgs,
+)
 
 
 class PackageType(Enum):
@@ -42,7 +48,7 @@ class EModelConfigParser(ConfigParser):
         return PackageType[self.get("Package", "type")]
 
     def hoc_paths_args(self):
-        """Get the config data subgroup containing the paths to the hoc files. """
+        """Get the config data subgroup containing the paths to the hoc files."""
         return HocPaths(
             hoc_dir=self.get("Paths", "memodel_dir"),
             cell_hoc_filename=self.get("Paths", "cell_hoc_file"),
@@ -68,7 +74,7 @@ class EModelConfigParser(ConfigParser):
         """Get the data from config used when loading synapse mechanisms."""
         if add_synapses is None:
             add_synapses = self.getboolean("Synapses", "add_synapses")
-            
+
         return SynMechArgs(
             add_synapses=add_synapses,
             seed=self.getint("Synapses", "seed"),

--- a/emodelrunner/configuration/configparser.py
+++ b/emodelrunner/configuration/configparser.py
@@ -18,6 +18,8 @@
 from configparser import ConfigParser
 from enum import Enum
 
+from emodelrunner.configuration.subgroups import HocPaths, ProtArgs, SynMechArgs, MorphArgs, PresynStimArgs
+
 
 class PackageType(Enum):
     """Enumerator for the emodel package types."""
@@ -38,3 +40,85 @@ class EModelConfigParser(ConfigParser):
     def package_type(self):
         """Package type as a property."""
         return PackageType[self.get("Package", "type")]
+
+    def hoc_paths_args(self):
+        """Get the config data subgroup containing the paths to the hoc files. """
+        return HocPaths(
+            hoc_dir=self.get("Paths", "memodel_dir"),
+            cell_hoc_filename=self.get("Paths", "cell_hoc_file"),
+            simul_hoc_filename=self.get("Paths", "simul_hoc_file"),
+            run_hoc_filename=self.get("Paths", "run_hoc_file"),
+            syn_dir=self.get("Paths", "syn_dir"),
+            syn_dir_for_hoc=self.get("Paths", "syn_dir_for_hoc"),
+            syn_hoc_filename=self.get("Paths", "syn_hoc_file"),
+            main_protocol_filename=self.get("Paths", "main_protocol_file"),
+        )
+
+    def prot_args(self):
+        """Get the subgroup containing protocols configuration data."""
+        return ProtArgs(
+            emodel=self.get("Cell", "emodel"),
+            apical_point_isec=self.getint("Protocol", "apical_point_isec"),
+            mtype=self.get("Morphology", "mtype"),
+            prot_path=self.get("Paths", "prot_path"),
+            features_path=self.get("Paths", "features_path"),
+        )
+
+    def syn_mech_args(self):
+        """Get the data from config used when loading synapse mechanisms."""
+        return SynMechArgs(
+            add_synapses=self.getboolean("Synapses", "add_synapses"),
+            seed=self.getint("Synapses", "seed"),
+            rng_settings_mode=self.get("Synapses", "rng_settings_mode"),
+            syn_conf_file=self.get("Paths", "syn_conf_file"),
+            syn_data_file=self.get("Paths", "syn_data_file"),
+            syn_dir=self.get("Paths", "syn_dir"),
+        )
+
+    def morph_args(self):
+        """Get morphology arguments for SSCX from the configuration object."""
+        morph_args = {}
+        morph_args["morph_path"] = self.get("Paths", "morph_path")
+        morph_args["do_replace_axon"] = self.getboolean("Morphology", "do_replace_axon")
+
+        if self.package_type == PackageType.sscx:
+            morph_args["axon_hoc_path"] = self.get("Paths", "replace_axon_hoc_path")
+
+        return MorphArgs(**morph_args)
+
+
+    def synplas_morph_args(self, precell=False):
+        """Get morphology arguments for Synplas from the configuration object.
+
+        Args:
+            precell (bool): True to load precell morph. False to load usual morph.
+        """
+        # load morphology path
+        if precell:
+            morph_path = self.get("Paths", "precell_morph_path")
+        else:
+            morph_path = self.get("Paths", "morph_path")
+
+        morph_args = {
+            "morph_path": morph_path,
+            "do_replace_axon": self.getboolean("Morphology", "do_replace_axon"),
+        }
+        return MorphArgs(**morph_args)
+
+
+    def presyn_stim_args(self, pre_spike_train):
+        """Get the pre-synaptic stimulus config data.
+
+        Args:
+            pre_spike_train (list): times at which the synapses fire (ms)
+        """
+        # spikedelay is the time between the start of the stimulus
+        # and the precell spike time
+        spike_delay = self.getfloat("Protocol", "precell_spikedelay")
+
+        # stim train is the times at which to stimulate the precell
+        return PresynStimArgs(
+            stim_train=pre_spike_train - spike_delay,
+            amp=self.getfloat("Protocol", "precell_amplitude"),
+            width=self.getfloat("Protocol", "precell_width"),
+        )

--- a/emodelrunner/configuration/configparser.py
+++ b/emodelrunner/configuration/configparser.py
@@ -70,15 +70,19 @@ class EModelConfigParser(ConfigParser):
             features_path=self.get("Paths", "features_path"),
         )
 
-    def syn_mech_args(self, add_synapses=None):
+    def syn_mech_args(self, add_synapses=None, seed=None, rng_settings_mode=None):
         """Get the data from config used when loading synapse mechanisms."""
         if add_synapses is None:
             add_synapses = self.getboolean("Synapses", "add_synapses")
+        if seed is None:
+            seed = self.getint("Synapses", "seed")
+        if rng_settings_mode is None:
+            rng_settings_mode = self.get("Synapses", "rng_settings_mode")
 
         return SynMechArgs(
             add_synapses=add_synapses,
-            seed=self.getint("Synapses", "seed"),
-            rng_settings_mode=self.get("Synapses", "rng_settings_mode"),
+            seed=seed,
+            rng_settings_mode=rng_settings_mode,
             syn_conf_file=self.get("Paths", "syn_conf_file"),
             syn_data_file=self.get("Paths", "syn_data_file"),
             syn_dir=self.get("Paths", "syn_dir"),

--- a/emodelrunner/configuration/configparser.py
+++ b/emodelrunner/configuration/configparser.py
@@ -64,10 +64,13 @@ class EModelConfigParser(ConfigParser):
             features_path=self.get("Paths", "features_path"),
         )
 
-    def syn_mech_args(self):
+    def syn_mech_args(self, add_synapses=None):
         """Get the data from config used when loading synapse mechanisms."""
+        if add_synapses is None:
+            add_synapses = self.getboolean("Synapses", "add_synapses")
+            
         return SynMechArgs(
-            add_synapses=self.getboolean("Synapses", "add_synapses"),
+            add_synapses=add_synapses,
             seed=self.getint("Synapses", "seed"),
             rng_settings_mode=self.get("Synapses", "rng_settings_mode"),
             syn_conf_file=self.get("Paths", "syn_conf_file"),
@@ -86,7 +89,6 @@ class EModelConfigParser(ConfigParser):
 
         return MorphArgs(**morph_args)
 
-
     def synplas_morph_args(self, precell=False):
         """Get morphology arguments for Synplas from the configuration object.
 
@@ -104,7 +106,6 @@ class EModelConfigParser(ConfigParser):
             "do_replace_axon": self.getboolean("Morphology", "do_replace_axon"),
         }
         return MorphArgs(**morph_args)
-
 
     def presyn_stim_args(self, pre_spike_train):
         """Get the pre-synaptic stimulus config data.

--- a/emodelrunner/configuration/subgroups.py
+++ b/emodelrunner/configuration/subgroups.py
@@ -43,12 +43,29 @@ class ProtArgs():
 
 @dataclass
 class SynMechArgs():
-    """Contains data needed to create synapse mechanimsms."""
+    """Contains data needed to create synapse mechanimsms.
+    
+    Attributes can be accessed only if add_synapses is True.
+    """
+    add_synapses: bool
     seed: int
     rng_settings_mode: str
     syn_conf_file: str
     syn_data_file: str
     syn_dir: str
+
+    def __getattribute__(self, item):
+        """Modified getattribute to restrict access to when add_synapses is True.
+        
+        Raises:
+            AttributeError when an attribute other than add_synapses is looked for and
+                add_synapses is False
+        """
+        if item != "add_synapses" and not self.add_synapses:
+            raise AttributeError(
+                f"You can not access {item} if add_synapses is {self.add_synapses}."
+            )
+        return super().__getattribute__(item)
 
 
 @dataclass

--- a/emodelrunner/configuration/subgroups.py
+++ b/emodelrunner/configuration/subgroups.py
@@ -1,0 +1,67 @@
+"""Dataclasses containing subgroups of config data."""
+
+# Copyright 2020-2022 Blue Brain Project / EPFL
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class HocPaths():
+    """Contains paths relative to hoc files creation."""
+    hoc_dir: str
+    cell_hoc_filename: str
+    simul_hoc_filename: str
+    run_hoc_filename: str
+    syn_dir: str
+    syn_dir_for_hoc: str
+    syn_hoc_filename: str
+    main_protocol_filename: str
+
+
+@dataclass
+class ProtArgs():
+    """Contains data needed to create protocols."""
+    emodel: str
+    apical_point_isec: int
+    mtype: str
+    prot_path: str
+    features_path: str
+
+
+@dataclass
+class SynMechArgs():
+    """Contains data needed to create synapse mechanimsms."""
+    seed: int
+    rng_settings_mode: str
+    syn_conf_file: str
+    syn_data_file: str
+    syn_dir: str
+
+
+@dataclass
+class MorphArgs():
+    """Contains data relative to morphology."""
+    morph_path: str
+    do_replace_axon: bool
+    axon_hoc_path: Optional[str] = None
+
+
+@dataclass
+class PresynStimArgs():
+    """Contains data relative to the presynaptic cell stimuli."""
+    stim_train: float
+    amp: float
+    width: float

--- a/emodelrunner/configuration/subgroups.py
+++ b/emodelrunner/configuration/subgroups.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 
-@dataclass
+@dataclass(frozen=True)
 class HocPaths:
     """Contains paths relative to hoc files creation."""
 
@@ -33,7 +33,7 @@ class HocPaths:
     main_protocol_filename: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProtArgs:
     """Contains data needed to create protocols."""
 
@@ -44,7 +44,7 @@ class ProtArgs:
     features_path: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class SynMechArgs:
     """Contains data needed to create synapse mechanimsms.
 
@@ -72,7 +72,7 @@ class SynMechArgs:
         return super().__getattribute__(item)
 
 
-@dataclass
+@dataclass(frozen=True)
 class MorphArgs:
     """Contains data relative to morphology."""
 
@@ -81,7 +81,7 @@ class MorphArgs:
     axon_hoc_path: Optional[str] = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class PresynStimArgs:
     """Contains data relative to the presynaptic cell stimuli."""
 

--- a/emodelrunner/configuration/subgroups.py
+++ b/emodelrunner/configuration/subgroups.py
@@ -18,9 +18,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
 @dataclass
-class HocPaths():
+class HocPaths:
     """Contains paths relative to hoc files creation."""
+
     hoc_dir: str
     cell_hoc_filename: str
     simul_hoc_filename: str
@@ -32,8 +34,9 @@ class HocPaths():
 
 
 @dataclass
-class ProtArgs():
+class ProtArgs:
     """Contains data needed to create protocols."""
+
     emodel: str
     apical_point_isec: int
     mtype: str
@@ -42,11 +45,12 @@ class ProtArgs():
 
 
 @dataclass
-class SynMechArgs():
+class SynMechArgs:
     """Contains data needed to create synapse mechanimsms.
-    
+
     Attributes can be accessed only if add_synapses is True.
     """
+
     add_synapses: bool
     seed: int
     rng_settings_mode: str
@@ -56,7 +60,7 @@ class SynMechArgs():
 
     def __getattribute__(self, item):
         """Modified getattribute to restrict access to when add_synapses is True.
-        
+
         Raises:
             AttributeError when an attribute other than add_synapses is looked for and
                 add_synapses is False
@@ -69,16 +73,18 @@ class SynMechArgs():
 
 
 @dataclass
-class MorphArgs():
+class MorphArgs:
     """Contains data relative to morphology."""
+
     morph_path: str
     do_replace_axon: bool
     axon_hoc_path: Optional[str] = None
 
 
 @dataclass
-class PresynStimArgs():
+class PresynStimArgs:
     """Contains data relative to the presynaptic cell stimuli."""
+
     stim_train: float
     amp: float
     width: float

--- a/emodelrunner/create_cells.py
+++ b/emodelrunner/create_cells.py
@@ -152,7 +152,7 @@ def get_postcell(
 
     unopt_params_path = config.get("Paths", "unoptimized_params_path")
 
-    syn_mech_args = config.syn_mech_args()
+    syn_mech_args = config.syn_mech_args(add_synapses=True)
     # rewrite seed and rng setting mode over basic emodelrunner config defaults
     syn_mech_args.seed = base_seed
     syn_mech_args.rng_settings_mode = "Compatibility"

--- a/emodelrunner/create_cells.py
+++ b/emodelrunner/create_cells.py
@@ -50,7 +50,7 @@ def create_cell(
         add_synapses (bool): whether to add synapses to the cell
         morph (ephys.morphologies.NrnFileMorphology): morphology object
         gid (int): cell model ID
-        syn_mech_args (dict): synapse-related configuration
+        syn_mech_args (SynMechArgs): synapse-related configuration
         use_glu_synapse (bool): whether to use GluSynapseCustom class for synapses
         fixhp (bool): to uninsert SK_E2 for hyperpolarization in cell model
         syn_setup_params (dict): contains extra parameters to setup synapses
@@ -69,10 +69,10 @@ def create_cell(
     if add_synapses:
         mechs += [
             load_syn_mechs(
-                syn_mech_args["seed"],
-                syn_mech_args["rng_settings_mode"],
-                os.path.join(syn_mech_args["syn_dir"], syn_mech_args["syn_data_file"]),
-                os.path.join(syn_mech_args["syn_dir"], syn_mech_args["syn_conf_file"]),
+                syn_mech_args.seed,
+                syn_mech_args.rng_settings_mode,
+                os.path.join(syn_mech_args.syn_dir, syn_mech_args.syn_data_file),
+                os.path.join(syn_mech_args.syn_dir, syn_mech_args.syn_conf_file),
                 use_glu_synapse=use_glu_synapse,
                 syn_setup_params=syn_setup_params,
             )
@@ -157,8 +157,8 @@ def get_postcell(
 
     syn_mech_args = get_syn_mech_args(config)
     # rewrite seed and rng setting mode over basic emodelrunner config defaults
-    syn_mech_args["seed"] = base_seed
-    syn_mech_args["rng_settings_mode"] = "Compatibility"
+    syn_mech_args.seed = base_seed
+    syn_mech_args.rng_settings_mode = "Compatibility"
 
     morph = create_morphology(get_synplas_morph_args(config), config.package_type)
 

--- a/emodelrunner/create_cells.py
+++ b/emodelrunner/create_cells.py
@@ -153,7 +153,9 @@ def get_postcell(
     unopt_params_path = config.get("Paths", "unoptimized_params_path")
 
     # rewrite seed and rng setting mode over basic emodelrunner config defaults
-    syn_mech_args = config.syn_mech_args(add_synapses=True, seed=base_seed, rng_settings_mode="Compatibility")
+    syn_mech_args = config.syn_mech_args(
+        add_synapses=True, seed=base_seed, rng_settings_mode="Compatibility"
+    )
 
     morph = create_morphology(config.synplas_morph_args(), config.package_type)
 

--- a/emodelrunner/create_cells.py
+++ b/emodelrunner/create_cells.py
@@ -18,12 +18,9 @@ import os
 
 from emodelrunner.cell import CellModelCustom
 from emodelrunner.load import (
-    get_morph_args,
     load_mechanisms,
     load_syn_mechs,
     load_unoptimized_parameters,
-    get_synplas_morph_args,
-    get_syn_mech_args,
 )
 from emodelrunner.morphology import create_morphology
 from emodelrunner.configuration import PackageType
@@ -111,11 +108,11 @@ def create_cell_using_config(config):
 
     # get synapse config data
     add_synapses = config.getboolean("Synapses", "add_synapses")
-    syn_mech_args = get_syn_mech_args(config)
+    syn_mech_args = config.syn_mech_args()
 
     # get morphology config data
     if config.package_type in [PackageType.sscx, PackageType.thalamus]:
-        morph = create_morphology(get_morph_args(config), config.package_type)
+        morph = create_morphology(config.morph_args(), config.package_type)
     else:
         raise ValueError(f"unsupported package type: {config.package_type}")
 
@@ -155,12 +152,12 @@ def get_postcell(
 
     unopt_params_path = config.get("Paths", "unoptimized_params_path")
 
-    syn_mech_args = get_syn_mech_args(config)
+    syn_mech_args = config.syn_mech_args()
     # rewrite seed and rng setting mode over basic emodelrunner config defaults
     syn_mech_args.seed = base_seed
     syn_mech_args.rng_settings_mode = "Compatibility"
 
-    morph = create_morphology(get_synplas_morph_args(config), config.package_type)
+    morph = create_morphology(config.synplas_morph_args(), config.package_type)
 
     add_synapses = True
 
@@ -201,7 +198,7 @@ def get_precell(
     unopt_params_path = config.get("Paths", "precell_unoptimized_params_path")
 
     morph = create_morphology(
-        get_synplas_morph_args(config, precell=True), config.package_type
+        config.synplas_morph_args(precell=True), config.package_type
     )
 
     add_synapses = False

--- a/emodelrunner/create_cells.py
+++ b/emodelrunner/create_cells.py
@@ -152,10 +152,8 @@ def get_postcell(
 
     unopt_params_path = config.get("Paths", "unoptimized_params_path")
 
-    syn_mech_args = config.syn_mech_args(add_synapses=True)
     # rewrite seed and rng setting mode over basic emodelrunner config defaults
-    syn_mech_args.seed = base_seed
-    syn_mech_args.rng_settings_mode = "Compatibility"
+    syn_mech_args = config.syn_mech_args(add_synapses=True, seed=base_seed, rng_settings_mode="Compatibility")
 
     morph = create_morphology(config.synplas_morph_args(), config.package_type)
 

--- a/emodelrunner/create_hoc.py
+++ b/emodelrunner/create_hoc.py
@@ -105,7 +105,7 @@ def get_hoc(config):
     main_protocol_template_path = config.get("Paths", "main_protocol_template_path")
     add_synapses = config.getboolean("Synapses", "add_synapses")
     syn_temp_name = config.get("Synapses", "hoc_synapse_template_name")
-    hoc_paths = config.get_hoc_paths_args()
+    hoc_paths = config.hoc_paths_args()
     apical_point_isec = config.get("Protocol", "apical_point_isec")
 
     constants_args = {
@@ -165,7 +165,9 @@ def get_hoc(config):
     )
 
     if main_protocol:
-        rin_exp_voltage_base = get_rin_exp_voltage_base(config.get("Paths", "features_path"))
+        rin_exp_voltage_base = get_rin_exp_voltage_base(
+            config.get("Paths", "features_path")
+        )
 
         main_protocol_hoc = create_main_protocol_hoc(
             template_path=main_protocol_template_path,
@@ -215,7 +217,7 @@ if __name__ == "__main__":
         config=config_
     )
 
-    hoc_paths_ = config_.get_hoc_paths_args()
+    hoc_paths_ = config_.hoc_paths_args()
     if main_protocol_hoc_:
         copy_features_hoc(config_)
     write_hocs(

--- a/emodelrunner/create_hoc.py
+++ b/emodelrunner/create_hoc.py
@@ -53,7 +53,7 @@ def write_hocs(
     """Write hoc files.
 
     Args:
-        hoc_paths (dict): contains paths of the hoc files to be created
+        hoc_paths (HocPaths): contains paths of the hoc files to be created
             See load.get_hoc_paths_args for details
         cell_hoc (str): content of the cell hoc file
         simul_hoc (str): content of the 'create simulation' hoc file
@@ -62,22 +62,22 @@ def write_hocs(
         main_protocol_hoc (str): content of the main protocol hoc file
     """
     # cell hoc
-    write_hoc(hoc_paths["hoc_dir"], hoc_paths["cell_hoc_filename"], cell_hoc)
+    write_hoc(hoc_paths.hoc_dir, hoc_paths.cell_hoc_filename, cell_hoc)
 
     # createsimulation.hoc
-    write_hoc(hoc_paths["hoc_dir"], hoc_paths["simul_hoc_filename"], simul_hoc)
+    write_hoc(hoc_paths.hoc_dir, hoc_paths.simul_hoc_filename, simul_hoc)
 
     # run.hoc
-    write_hoc(hoc_paths["hoc_dir"], hoc_paths["run_hoc_filename"], run_hoc)
+    write_hoc(hoc_paths.hoc_dir, hoc_paths.run_hoc_filename, run_hoc)
 
     # synapses hoc
     if syn_hoc is not None:
-        write_hoc(hoc_paths["syn_dir"], hoc_paths["syn_hoc_filename"], syn_hoc)
+        write_hoc(hoc_paths.syn_dir, hoc_paths.syn_hoc_filename, syn_hoc)
 
     # main protocol hoc
     if main_protocol_hoc is not None:
         write_hoc(
-            hoc_paths["hoc_dir"], hoc_paths["main_protocol_filename"], main_protocol_hoc
+            hoc_paths.hoc_dir, hoc_paths.main_protocol_filename, main_protocol_hoc
         )
 
 
@@ -147,8 +147,8 @@ def get_hoc(config):
     cell_hoc = cell.create_custom_hoc(
         release_params,
         template_path=cell_template_path,
-        syn_dir=hoc_paths["syn_dir_for_hoc"],
-        syn_hoc_filename=hoc_paths["syn_hoc_filename"],
+        syn_dir=hoc_paths.syn_dir_for_hoc,
+        syn_hoc_filename=hoc_paths.syn_hoc_filename,
         syn_temp_name=syn_temp_name,
     )
 
@@ -199,7 +199,7 @@ def get_hoc(config):
         # get synapse hoc
         syn_hoc = create_synapse_hoc(
             syn_mech_args=syn_mech_args,
-            syn_hoc_dir=hoc_paths["syn_dir_for_hoc"],
+            syn_hoc_dir=hoc_paths.syn_dir_for_hoc,
             template_path=synapses_template_path,
             gid=cell.gid,
             dt=constants_args["dt"],

--- a/emodelrunner/create_hoc_tools.py
+++ b/emodelrunner/create_hoc_tools.py
@@ -598,7 +598,6 @@ def create_simul_hoc(
         template_path (str): path to the template to fill in
         add_synapses (bool): whether to add synapses to the cell
         hoc_paths (HocPaths): contains paths of the hoc files to be created
-            See load.get_hoc_paths_args for details
         constants_args (dict): contains data about the constants of the simulation
         protocol_definitions (dict): dictionary defining the protocols.
             Should have the structure of the protocol file in example/sscx/config/protocols

--- a/emodelrunner/create_hoc_tools.py
+++ b/emodelrunner/create_hoc_tools.py
@@ -480,7 +480,7 @@ def create_synapse_hoc(
     """Returns a string containing the synapse hoc.
 
     Args:
-        syn_mech_args (dict): synapse-related configuration
+        syn_mech_args (SynMechArgs): synapse-related configuration
         syn_hoc_dir (str): path to directory containing synapse-related data
         template_path (str): path to the template to fill in
         gid (int): cell ID
@@ -499,11 +499,11 @@ def create_synapse_hoc(
     return template.render(
         TEMPLATENAME=synapses_template_name,
         GID=gid,
-        SEED=syn_mech_args["seed"],
-        rng_settings_mode=syn_mech_args["rng_settings_mode"],
+        SEED=syn_mech_args.seed,
+        rng_settings_mode=syn_mech_args.rng_settings_mode,
         syn_dir=syn_hoc_dir,
-        syn_conf_file=syn_mech_args["syn_conf_file"],
-        syn_data_file=syn_mech_args["syn_data_file"],
+        syn_conf_file=syn_mech_args.syn_conf_file,
+        syn_data_file=syn_mech_args.syn_data_file,
         dt=dt,
     )
 
@@ -597,7 +597,7 @@ def create_simul_hoc(
     Args:
         template_path (str): path to the template to fill in
         add_synapses (bool): whether to add synapses to the cell
-        hoc_paths (dict): contains paths of the hoc files to be created
+        hoc_paths (HocPaths): contains paths of the hoc files to be created
             See load.get_hoc_paths_args for details
         constants_args (dict): contains data about the constants of the simulation
         protocol_definitions (dict): dictionary defining the protocols.
@@ -608,9 +608,9 @@ def create_simul_hoc(
     Returns:
         str: hoc script to create the simulation
     """
-    syn_dir = hoc_paths["syn_dir_for_hoc"]
-    syn_hoc_file = hoc_paths["syn_hoc_filename"]
-    cell_hoc_file = hoc_paths["cell_hoc_filename"]
+    syn_dir = hoc_paths.syn_dir_for_hoc
+    syn_hoc_file = hoc_paths.syn_hoc_filename
+    cell_hoc_file = hoc_paths.cell_hoc_filename
 
     hoc_stim_creator = HocStimuliCreator(
         protocol_definitions,

--- a/emodelrunner/load.py
+++ b/emodelrunner/load.py
@@ -22,9 +22,7 @@ from bluepyopt import ephys
 
 from emodelrunner.synapses.mechanism import NrnMODPointProcessMechanismCustom
 from emodelrunner.locations import multi_locations
-from emodelrunner.configuration import (
-    get_validated_config, PackageType, HocPaths, ProtArgs, SynMechArgs, MorphArgs, PresynStimArgs
-)
+from emodelrunner.configuration import get_validated_config, PackageType
 
 
 def load_config(config_path):
@@ -37,127 +35,6 @@ def load_config(config_path):
         configparser.ConfigParser: loaded config object
     """
     return get_validated_config(config_path)
-
-
-def get_hoc_paths_args(config):
-    """Get the config data subgroup containing the paths to the hoc files.
-
-    Args:
-        config (configparser.ConfigParser): configuration
-
-    Returns:
-        HocPaths: hoc paths related configuration data
-    """
-    return HocPaths(
-        hoc_dir=config.get("Paths", "memodel_dir"),
-        cell_hoc_filename=config.get("Paths", "cell_hoc_file"),
-        simul_hoc_filename=config.get("Paths", "simul_hoc_file"),
-        run_hoc_filename=config.get("Paths", "run_hoc_file"),
-        syn_dir=config.get("Paths", "syn_dir"),
-        syn_dir_for_hoc=config.get("Paths", "syn_dir_for_hoc"),
-        syn_hoc_filename=config.get("Paths", "syn_hoc_file"),
-        main_protocol_filename=config.get("Paths", "main_protocol_file"),
-    )
-
-
-def get_prot_args(config):
-    """Get the subgroup containing protocols configuration data.
-
-    Args:
-        config (configparser.ConfigParser): configuration
-
-    Returns:
-        ProtArgs: protocol related configuration data
-    """
-    return ProtArgs(
-        emodel=config.get("Cell", "emodel"),
-        apical_point_isec=config.getint("Protocol", "apical_point_isec"),
-        mtype=config.get("Morphology", "mtype"),
-        prot_path=config.get("Paths", "prot_path"),
-        features_path=config.get("Paths", "features_path"),
-    )
-
-
-def get_syn_mech_args(config):
-    """Get the data from config used when loading synapse mechanisms.
-
-    Args:
-        config (configparser.ConfigParser): configuration
-
-    Returns:
-        SynMechArgs: synapse related configuration data
-    """
-    return SynMechArgs(
-        seed=config.getint("Synapses", "seed"),
-        rng_settings_mode=config.get("Synapses", "rng_settings_mode"),
-        syn_conf_file=config.get("Paths", "syn_conf_file"),
-        syn_data_file=config.get("Paths", "syn_data_file"),
-        syn_dir=config.get("Paths", "syn_dir"),
-    )
-
-
-def get_morph_args(config):
-    """Get morphology arguments for SSCX from the configuration object.
-
-    Args:
-        config (configparser.ConfigParser): configuration object.
-
-    Returns:
-        MorphArgs: morphology-related configuration data.
-    """
-    morph_args = {}
-    morph_args["morph_path"] = config.get("Paths", "morph_path")
-    morph_args["do_replace_axon"] = config.getboolean("Morphology", "do_replace_axon")
-
-    if config.package_type == PackageType.sscx:
-        morph_args["axon_hoc_path"] = config.get("Paths", "replace_axon_hoc_path")
-
-    return MorphArgs(**morph_args)
-
-
-def get_synplas_morph_args(config, precell=False):
-    """Get morphology arguments for Synplas from the configuration object.
-
-    Args:
-        config (configparser.ConfigParser): configuration
-        precell (bool): True to load precell morph. False to load usual morph.
-
-    Returns:
-        MorphArgs: morphology-related configuration data.
-    """
-    # load morphology path
-    if precell:
-        morph_path = config.get("Paths", "precell_morph_path")
-    else:
-        morph_path = config.get("Paths", "morph_path")
-
-    morph_args = {
-        "morph_path": morph_path,
-        "do_replace_axon": config.getboolean("Morphology", "do_replace_axon"),
-    }
-    return MorphArgs(**morph_args)
-
-
-def get_presyn_stim_args(config, pre_spike_train):
-    """Get the pre-synaptic stimulus config data.
-
-    Args:
-        config (configparser.ConfigParser): configuration
-        pre_spike_train (list): times at which the synapses fire (ms)
-
-    Returns:
-        PresynStimArgs: presynaptic stimuli related configuration data
-    """
-    # spikedelay is the time between the start of the stimulus
-    # and the precell spike time
-    spike_delay = config.getfloat("Protocol", "precell_spikedelay")
-
-    # stim train is the times at which to stimulate the precell
-    return PresynStimArgs(
-        stim_train=pre_spike_train - spike_delay,
-        amp=config.getfloat("Protocol", "precell_amplitude"),
-        width=config.getfloat("Protocol", "precell_width"),
-    )
 
 
 def load_emodel_params(emodel, params_path):
@@ -406,6 +283,24 @@ def load_unoptimized_parameters(params_path, v_init, celsius):
                     )
 
     return parameters
+
+
+def get_rin_exp_voltage_base(features_path):
+    """Get experimental rin voltage base from feature file when having MainProtocol."""
+    with open(features_path, "r", encoding="utf-8") as features_file:
+        feature_definitions = json.load(features_file)
+
+    rin_exp_voltage_base = None
+    for feature in feature_definitions["Rin"]["soma.v"]:
+        if feature["feature"] == "voltage_base":
+            rin_exp_voltage_base = feature["val"][0]
+
+    if rin_exp_voltage_base is None:
+        raise KeyError(
+            f"No voltage_base feature found for 'Rin' in {features_filename}"
+        )
+
+    return rin_exp_voltage_base
 
 
 def load_syn_mechs(

--- a/emodelrunner/load.py
+++ b/emodelrunner/load.py
@@ -22,7 +22,7 @@ from bluepyopt import ephys
 
 from emodelrunner.synapses.mechanism import NrnMODPointProcessMechanismCustom
 from emodelrunner.locations import multi_locations
-from emodelrunner.configuration import get_validated_config, PackageType
+from emodelrunner.configuration import get_validated_config
 
 
 def load_config(config_path):
@@ -296,9 +296,7 @@ def get_rin_exp_voltage_base(features_path):
             rin_exp_voltage_base = feature["val"][0]
 
     if rin_exp_voltage_base is None:
-        raise KeyError(
-            f"No voltage_base feature found for 'Rin' in {features_filename}"
-        )
+        raise KeyError(f"No voltage_base feature found for 'Rin' in {features_path}")
 
     return rin_exp_voltage_base
 

--- a/emodelrunner/morphology/builder.py
+++ b/emodelrunner/morphology/builder.py
@@ -38,7 +38,7 @@ def create_morphology(morph_args, package_type):
     """Creates the morphology object.
 
     Args:
-        morph_args (dict): morphology-related configuration
+        morph_args (MorphArgs): morphology-related configuration
         package_type (Enum): enum denoting the package type
 
     Raises:
@@ -47,20 +47,20 @@ def create_morphology(morph_args, package_type):
     Returns:
         ephys.morphologies.NrnFileMorphology: morphology object
     """
-    try:
-        replace_axon_hoc = get_axon_hoc(morph_args["axon_hoc_path"])
-    except KeyError:
-        replace_axon_hoc = None
+    replace_axon_hoc = None
+    if morph_args.axon_hoc_path is not None:
+        replace_axon_hoc = get_axon_hoc(morph_args.axon_hoc_path)
+
     if package_type in [PackageType.sscx, PackageType.synplas]:
         morph = SSCXNrnFileMorphology(
-            morph_args["morph_path"],
-            do_replace_axon=morph_args["do_replace_axon"],
+            morph_args.morph_path,
+            do_replace_axon=morph_args.do_replace_axon,
             replace_axon_hoc=replace_axon_hoc,
         )
     elif package_type == PackageType.thalamus:
         morph = ThalamusNrnFileMorphology(
-            morph_args["morph_path"],
-            do_replace_axon=morph_args["do_replace_axon"],
+            morph_args.morph_path,
+            do_replace_axon=morph_args.do_replace_axon,
             replace_axon_hoc=replace_axon_hoc,
         )
     else:

--- a/emodelrunner/protocols/create_protocols.py
+++ b/emodelrunner/protocols/create_protocols.py
@@ -71,7 +71,6 @@ class ProtocolBuilder:
         Args:
             add_synapses (bool): whether to add synapses to the cell
             prot_args (ProtArgs): config data relative to protocols
-                See load.get_prot_args for details
             cell (CellModelCustom): cell model
         Returns:
             ProtocolBuilder: the object with the sscx protocols
@@ -95,7 +94,6 @@ class ProtocolBuilder:
         Args:
             add_synapses (bool): whether to add synapses to the cell
             prot_args (ProtArgs): config data relative to protocols
-                See load.get_prot_args for details
             cell (CellModelCustom): cell model
         Returns:
             ProtocolBuilder: the object with the thalamus protocols
@@ -410,7 +408,6 @@ def define_pairsim_protocols(
         tstop (float): total duration of the simulation (ms)
         fastforward (float): time at which to enable synapse fast-forwarding (ms)
         presyn_stim_args (PresynStimArgs): presynaptic stimulus configuration data
-            See load.get_presyn_stim_args for details
         stim_path (str): path to the pulse stimuli file
 
     Returns:

--- a/emodelrunner/protocols/create_protocols.py
+++ b/emodelrunner/protocols/create_protocols.py
@@ -70,7 +70,7 @@ class ProtocolBuilder:
 
         Args:
             add_synapses (bool): whether to add synapses to the cell
-            prot_args (dict): config data relative to protocols
+            prot_args (ProtArgs): config data relative to protocols
                 See load.get_prot_args for details
             cell (CellModelCustom): cell model
         Returns:
@@ -79,11 +79,11 @@ class ProtocolBuilder:
         syn_locs = cls._get_syn_locs(add_synapses, cell)
 
         protocols = create_protocols_object(
-            apical_point_isec=prot_args["apical_point_isec"],
-            prot_path=prot_args["prot_path"],
+            apical_point_isec=prot_args.apical_point_isec,
+            prot_path=prot_args.prot_path,
             package_type=PackageType.sscx,
-            features_path=prot_args["features_path"],
-            mtype=prot_args["mtype"],
+            features_path=prot_args.features_path,
+            mtype=prot_args.mtype,
             syn_locs=syn_locs,
         )
         return cls(protocols)
@@ -94,7 +94,7 @@ class ProtocolBuilder:
 
         Args:
             add_synapses (bool): whether to add synapses to the cell
-            prot_args (dict): config data relative to protocols
+            prot_args (ProtArgs): config data relative to protocols
                 See load.get_prot_args for details
             cell (CellModelCustom): cell model
         Returns:
@@ -103,11 +103,11 @@ class ProtocolBuilder:
         syn_locs = cls._get_syn_locs(add_synapses, cell)
 
         protocols = create_protocols_object(
-            apical_point_isec=prot_args["apical_point_isec"],
-            prot_path=prot_args["prot_path"],
+            apical_point_isec=prot_args.apical_point_isec,
+            prot_path=prot_args.prot_path,
             package_type=PackageType.thalamus,
-            features_path=prot_args["features_path"],
-            mtype=prot_args["mtype"],
+            features_path=prot_args.features_path,
+            mtype=prot_args.mtype,
             syn_locs=syn_locs,
         )
         return cls(protocols)
@@ -409,7 +409,7 @@ def define_pairsim_protocols(
         synrecs (list of str): the extra synapse variables to record
         tstop (float): total duration of the simulation (ms)
         fastforward (float): time at which to enable synapse fast-forwarding (ms)
-        presyn_stim_args (dict): presynaptic stimulus configuration data
+        presyn_stim_args (PresynStimArgs): presynaptic stimulus configuration data
             See load.get_presyn_stim_args for details
         stim_path (str): path to the pulse stimuli file
 
@@ -435,9 +435,9 @@ def define_pairsim_protocols(
     presyn_stims = [
         MultipleSteps(
             soma_loc,
-            presyn_stim_args["stim_train"],
-            presyn_stim_args["amp"],
-            presyn_stim_args["width"],
+            presyn_stim_args.stim_train,
+            presyn_stim_args.amp,
+            presyn_stim_args.width,
         )
     ]
 

--- a/emodelrunner/run.py
+++ b/emodelrunner/run.py
@@ -24,7 +24,6 @@ from emodelrunner.parsing_utilities import get_parser_args, set_verbosity
 from emodelrunner.protocols.create_protocols import ProtocolBuilder
 from emodelrunner.load import (
     load_config,
-    get_prot_args,
     get_release_params,
 )
 from emodelrunner.output import write_current
@@ -54,7 +53,7 @@ def main(config_path):
 
     # create protocols
     add_synapses = config.getboolean("Synapses", "add_synapses")
-    prot_args = get_prot_args(config)
+    prot_args = config.prot_args()
 
     if config.package_type == PackageType.sscx:
         protocols = ProtocolBuilder.using_sscx_protocols(add_synapses, prot_args, cell)

--- a/emodelrunner/run_pairsim.py
+++ b/emodelrunner/run_pairsim.py
@@ -22,7 +22,6 @@ from bluepyopt import ephys
 from emodelrunner.create_cells import get_precell, get_postcell
 from emodelrunner.parsing_utilities import get_parser_args, set_verbosity
 from emodelrunner.protocols.create_protocols import define_pairsim_protocols
-from emodelrunner.load import get_presyn_stim_args
 from emodelrunner.load import get_release_params
 from emodelrunner.load import get_syn_setup_params
 from emodelrunner.load import load_config
@@ -87,7 +86,7 @@ def run(
     pre_spike_train = np.unique(np.loadtxt(spike_train_path, skiprows=1)[:, 0])
 
     # get pre-synaptic stimulus parameters
-    presyn_stim_args = get_presyn_stim_args(config, pre_spike_train)
+    presyn_stim_args = config.presyn_stim_args(pre_spike_train)
 
     # Set fitted model parameters
     if syn_setup_params["fit_params"]:

--- a/tests/sscx_tests/test_emodelrunner.py
+++ b/tests/sscx_tests/test_emodelrunner.py
@@ -28,7 +28,6 @@ from bluepyopt import ephys
 from emodelrunner.create_hoc import get_hoc, write_hocs, copy_features_hoc
 from emodelrunner.load import (
     load_config,
-    get_hoc_paths_args,
 )
 from emodelrunner.protocols import sscx_protocols
 from emodelrunner.run import main as run_emodel
@@ -72,7 +71,7 @@ def test_voltages():
             cell_hoc, syn_hoc, simul_hoc, run_hoc, main_prot_hoc = get_hoc(
                 config=config
             )
-            hoc_paths = get_hoc_paths_args(config)
+            hoc_paths = config.hoc_paths_args()
             write_hocs(hoc_paths, cell_hoc, simul_hoc, run_hoc, syn_hoc, main_prot_hoc)
 
             subprocess.call(["sh", "./run_hoc.sh"])
@@ -127,7 +126,7 @@ def test_synapses_hoc_vs_py_script(config_path="config/config_synapses_short.ini
             cell_hoc, syn_hoc, simul_hoc, run_hoc, main_prot_hoc = get_hoc(
                 config=config
             )
-            hoc_paths = get_hoc_paths_args(config)
+            hoc_paths = config.hoc_paths_args()
             write_hocs(hoc_paths, cell_hoc, simul_hoc, run_hoc, syn_hoc, main_prot_hoc)
 
             subprocess.call(["sh", "./run_hoc.sh"])
@@ -153,7 +152,7 @@ def test_recipe_protocols():
             cell_hoc, syn_hoc, simul_hoc, run_hoc, main_prot_hoc = get_hoc(
                 config=config
             )
-            hoc_paths = get_hoc_paths_args(config)
+            hoc_paths = config.hoc_paths_args()
             copy_features_hoc(config)
             write_hocs(hoc_paths, cell_hoc, simul_hoc, run_hoc, syn_hoc, main_prot_hoc)
 
@@ -351,7 +350,7 @@ def test_multiprotocols_hoc_vs_py_script(
             cell_hoc, syn_hoc, simul_hoc, run_hoc, main_prot_hoc = get_hoc(
                 config=config
             )
-            hoc_paths = get_hoc_paths_args(config)
+            hoc_paths = config.hoc_paths_args()
             write_hocs(hoc_paths, cell_hoc, simul_hoc, run_hoc, syn_hoc, main_prot_hoc)
 
             subprocess.call(["sh", "./run_hoc.sh"])

--- a/tests/unit_tests/protocols/test_create_protocols.py
+++ b/tests/unit_tests/protocols/test_create_protocols.py
@@ -21,7 +21,6 @@ import pytest
 
 from emodelrunner.load import (
     load_config,
-    get_prot_args,
 )
 from emodelrunner.create_cells import create_cell_using_config
 from emodelrunner.protocols.create_protocols import ProtocolBuilder
@@ -53,7 +52,7 @@ class TestProtocolBuilder:
             )
             cell = create_cell_using_config(config)
             add_synapses = config.getboolean("Synapses", "add_synapses")
-            prot_args = get_prot_args(config)
+            prot_args = config.prot_args()
 
             protocols = ProtocolBuilder.using_sscx_protocols(
                 add_synapses, prot_args, cell
@@ -87,7 +86,7 @@ class TestProtocolBuilder:
             config = load_config(
                 config_path=Path("config") / "config_recipe_protocols.ini"
             )
-        prot_args = get_prot_args(config)
+        prot_args = config.prot_args()
 
         with pytest.raises(RuntimeError):
             ProtocolBuilder.using_sscx_protocols(add_synapses, prot_args, cell)
@@ -100,7 +99,7 @@ class TestProtocolBuilder:
             )
             cell = create_cell_using_config(config)
             add_synapses = config.getboolean("Synapses", "add_synapses")
-            prot_args = get_prot_args(config)
+            prot_args = config.prot_args()
 
             protocols = ProtocolBuilder.using_thalamus_protocols(
                 add_synapses, prot_args, cell

--- a/tests/unit_tests/protocols/test_create_protocols.py
+++ b/tests/unit_tests/protocols/test_create_protocols.py
@@ -82,7 +82,12 @@ class TestProtocolBuilder:
         """Test building sscx protocols with a None cell to raise exception."""
         cell = None
         add_synapses = True
-        prot_args = {}
+
+        with cwd(sscx_sample_dir):
+            config = load_config(
+                config_path=Path("config") / "config_recipe_protocols.ini"
+            )
+        prot_args = get_prot_args(config)
 
         with pytest.raises(RuntimeError):
             ProtocolBuilder.using_sscx_protocols(add_synapses, prot_args, cell)

--- a/tests/unit_tests/protocols/test_reader.py
+++ b/tests/unit_tests/protocols/test_reader.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from emodelrunner.create_cells import create_cell_using_config
 from emodelrunner.load import (
     load_config,
-    get_prot_args,
 )
 from emodelrunner.protocols.reader import ProtocolParser
 from emodelrunner.synapses.create_locations import get_syn_locs
@@ -51,7 +50,7 @@ class TestProtocolParser:
             )
             cell = create_cell_using_config(config)
             syn_locs = get_syn_locs(cell)
-            prot_args = get_prot_args(config)
+            prot_args = config.prot_args()
 
             protocols_dict = ProtocolParser().parse_sscx_protocols(
                 protocols_filepath=prot_args.prot_path,
@@ -69,7 +68,7 @@ class TestProtocolParser:
             config = load_config(
                 config_path=Path("config") / "config_recipe_prots_short.ini"
             )
-            prot_args = get_prot_args(config)
+            prot_args = config.prot_args()
 
             protocols_dict = ProtocolParser().parse_thalamus_protocols(
                 protocols_filepath=prot_args.prot_path,

--- a/tests/unit_tests/protocols/test_reader.py
+++ b/tests/unit_tests/protocols/test_reader.py
@@ -54,9 +54,9 @@ class TestProtocolParser:
             prot_args = get_prot_args(config)
 
             protocols_dict = ProtocolParser().parse_sscx_protocols(
-                protocols_filepath=prot_args["prot_path"],
-                prefix=prot_args["mtype"],
-                apical_point_isec=prot_args["apical_point_isec"],
+                protocols_filepath=prot_args.prot_path,
+                prefix=prot_args.mtype,
+                apical_point_isec=prot_args.apical_point_isec,
                 syn_locs=syn_locs,
             )
 
@@ -72,8 +72,8 @@ class TestProtocolParser:
             prot_args = get_prot_args(config)
 
             protocols_dict = ProtocolParser().parse_thalamus_protocols(
-                protocols_filepath=prot_args["prot_path"],
-                prefix=prot_args["mtype"],
+                protocols_filepath=prot_args.prot_path,
+                prefix=prot_args.mtype,
             )
 
             assert set(protocols_dict.keys()) == thalamus_recipe_protocol_keys

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -142,5 +142,5 @@ def test_syn_mech_args_getattribute():
     with pytest.raises(AttributeError):
         _ = syn_mech_args.seed
 
-    syn_mech_args.add_synapses = True
+    syn_mech_args = config.syn_mech_args(add_synapses=True)
     _ = syn_mech_args.seed

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -130,3 +130,17 @@ def test_get_validated_config():
     invalid_conf = Path("tests") / "static_files" / "invalid_config.ini"
     with pytest.raises(ValueError):
         get_validated_config(invalid_conf)
+
+
+def test_syn_mech_args_getattribute():
+    """Test the __getattribute__ dunder method of SynMechArgs."""
+    with cwd(sscx_sample_dir):
+        config_path = Path(".") / "config" / "config_allsteps.ini"
+        config = get_validated_config(config_path)
+    syn_mech_args = config.syn_mech_args()
+    assert not syn_mech_args.add_synapses
+    with pytest.raises(AttributeError):
+        _ = syn_mech_args.seed
+
+    syn_mech_args.add_synapses = True
+    _ = syn_mech_args.seed

--- a/tests/unit_tests/test_morphology.py
+++ b/tests/unit_tests/test_morphology.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from pytest import raises
 
 
-from emodelrunner.load import load_config, get_morph_args
+from emodelrunner.load import load_config
 from emodelrunner.morphology import (
     create_morphology,
     SSCXNrnFileMorphology,
@@ -38,10 +38,10 @@ def test_create_morphology():
     with cwd(sscx_dir):
         config = load_config(config_path=Path("config") / "config_allsteps.ini")
 
-        sscx_morph = create_morphology(get_morph_args(config), PackageType.sscx)
+        sscx_morph = create_morphology(config.morph_args(), PackageType.sscx)
         assert isinstance(sscx_morph, SSCXNrnFileMorphology)
-        thal_morph = create_morphology(get_morph_args(config), PackageType.thalamus)
+        thal_morph = create_morphology(config.morph_args(), PackageType.thalamus)
         assert isinstance(thal_morph, ThalamusNrnFileMorphology)
 
         with raises(ValueError):
-            create_morphology(get_morph_args(config), "unknown_package_type")
+            create_morphology(config.morph_args(), "unknown_package_type")


### PR DESCRIPTION
- the subgroups of configuration data are no longer dictionaries, but dataclasses
- they are not created with functions in load module, but from methods in config class
- synapse mechanism data subgroup access is restricted to when add_synapses is True
- creation of get_rin_exp_voltage_base function in load, being called in create_hoc module