### PR TITLE
if not set, set logging level to INFO

### DIFF
--- a/emodelrunner/run.py
+++ b/emodelrunner/run.py
@@ -31,6 +31,10 @@ from emodelrunner.output import write_responses
 
 logger = logging.getLogger(__name__)
 
+# if logger.level is unset, then set it to INFO
+if logger.level == logging.NOTSET:
+    logger.setLevel(logging.INFO)
+
 
 def main(config_path):
     """Main.
@@ -82,7 +86,8 @@ def main(config_path):
     write_responses(responses, output_dir)
     write_current(currents, output_dir)
 
-    logger.info("Python Recordings Done")
+    logger.info("Python Recordings Done.")
+    logger.info(f"Responses written to {output_dir}")
 
 
 if __name__ == "__main__":

--- a/emodelrunner/run.py
+++ b/emodelrunner/run.py
@@ -87,7 +87,7 @@ def main(config_path):
     write_current(currents, output_dir)
 
     logger.info("Python Recordings Done.")
-    logger.info(f"Responses written to {output_dir}")
+    logger.info("Responses written to %s", output_dir)
 
 
 if __name__ == "__main__":

--- a/emodelrunner/run_pairsim.py
+++ b/emodelrunner/run_pairsim.py
@@ -31,6 +31,9 @@ from emodelrunner.run_synplas import _set_global_params
 
 # Configure logger
 logger = logging.getLogger(__name__)
+# if logger.level is unset, then set it to INFO
+if logger.level == logging.NOTSET:
+    logger.setLevel(logging.INFO)
 
 
 def run(
@@ -131,6 +134,7 @@ def run(
     )
 
     logger.info("Python Recordings Done.")
+    logger.info(f"Responses written to {output_path}")
 
 
 if __name__ == "__main__":

--- a/emodelrunner/run_pairsim.py
+++ b/emodelrunner/run_pairsim.py
@@ -134,7 +134,7 @@ def run(
     )
 
     logger.info("Python Recordings Done.")
-    logger.info(f"Responses written to {output_path}")
+    logger.info("Responses written to %s", output_path)
 
 
 if __name__ == "__main__":

--- a/emodelrunner/run_synplas.py
+++ b/emodelrunner/run_synplas.py
@@ -127,7 +127,7 @@ def run(
     write_synplas_output(responses, pre_spike_train, output_path, syn_prop_path)
 
     logger.info("Python Recordings Done.")
-    logger.info(f"Responses written to {output_path}.")
+    logger.info("Responses written to %s", output_dir)
 
 
 if __name__ == "__main__":

--- a/emodelrunner/run_synplas.py
+++ b/emodelrunner/run_synplas.py
@@ -127,7 +127,7 @@ def run(
     write_synplas_output(responses, pre_spike_train, output_path, syn_prop_path)
 
     logger.info("Python Recordings Done.")
-    logger.info("Responses written to %s", output_dir)
+    logger.info("Responses written to %s", output_path)
 
 
 if __name__ == "__main__":

--- a/emodelrunner/run_synplas.py
+++ b/emodelrunner/run_synplas.py
@@ -31,6 +31,9 @@ from emodelrunner.output import write_synplas_output
 
 # Configure logger
 logger = logging.getLogger(__name__)
+# if logger.level is unset, then set it to INFO
+if logger.level == logging.NOTSET:
+    logger.setLevel(logging.INFO)
 
 
 # taken from glusynapse.simulation.simulator
@@ -124,6 +127,7 @@ def run(
     write_synplas_output(responses, pre_spike_train, output_path, syn_prop_path)
 
     logger.info("Python Recordings Done.")
+    logger.info(f"Responses written to {output_path}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the CLI use cases the logger level is not set by default. In this case the root logger gets created with level WARNING [1].

This PR sets the logger level to INFO, if it is not set.

1. https://docs.python.org/3/library/logging.html#logging.Logger.setLevel