### PR TITLE
decay_time_constant_after_stim default on failing is None and not -1

### DIFF
--- a/emodelrunner/factsheets/physiology_features.py
+++ b/emodelrunner/factsheets/physiology_features.py
@@ -58,7 +58,9 @@ def extract_physiology_features(
 
     efel_results = efel.getFeatureValues([trace], ["ohmic_input_resistance_vb_ssse"])
     input_resistance = efel_results[0]["ohmic_input_resistance_vb_ssse"]
-    input_resistance = input_resistance[0] if input_resistance is not None else input_resistance
+    input_resistance = (
+        input_resistance[0] if input_resistance is not None else input_resistance
+    )
 
     return [voltage_base, input_resistance, dct]
 

--- a/emodelrunner/factsheets/physiology_features.py
+++ b/emodelrunner/factsheets/physiology_features.py
@@ -57,7 +57,8 @@ def extract_physiology_features(
     trace["stimulus_current"] = [current_amplitude]
 
     efel_results = efel.getFeatureValues([trace], ["ohmic_input_resistance_vb_ssse"])
-    input_resistance = efel_results[0]["ohmic_input_resistance_vb_ssse"][0]
+    input_resistance = efel_results[0]["ohmic_input_resistance_vb_ssse"]
+    input_resistance = input_resistance[0] if input_resistance is not None else input_resistance
 
     return [voltage_base, input_resistance, dct]
 

--- a/emodelrunner/factsheets/physiology_features.py
+++ b/emodelrunner/factsheets/physiology_features.py
@@ -50,7 +50,8 @@ def extract_physiology_features(
     )
 
     voltage_base = efel_results[0]["voltage_base"][0]
-    dct = efel_results[0]["decay_time_constant_after_stim"][0]
+    dct = efel_results[0]["decay_time_constant_after_stim"]
+    dct = dct[0] if dct is not None else dct
 
     trace["decay_start_after_stim"] = efel_results[0]["voltage_base"]
     trace["stimulus_current"] = [current_amplitude]


### PR DESCRIPTION
Because of changes in efel, some features that used to go back to a default value when something went wrong during computation now become None. This change is to take that into account.